### PR TITLE
Add multiselection mode

### DIFF
--- a/src/components/DffPlot.vue
+++ b/src/components/DffPlot.vue
@@ -54,13 +54,11 @@ export default {
 
     mode (mode) {
       if (mode === 'selection') {
-        // Hide the time index and highlight whatever trace is currently focused.
+        // Hide the time index.
         this.hideTimeIndex();
-        this.setFocus(this.focus);
       } else {
-        // Show the time index and turn off trace highlighting.
+        // Show the time index.
         this.showTimeIndex();
-        this.setFocus([]);
       }
     },
 

--- a/src/components/DffPlot.vue
+++ b/src/components/DffPlot.vue
@@ -60,7 +60,7 @@ export default {
       } else {
         // Show the time index and turn off trace highlighting.
         this.showTimeIndex();
-        this.setFocus(null);
+        this.setFocus([]);
       }
     },
 
@@ -90,7 +90,7 @@ export default {
       select(this.$el)
         .selectAll('path')
         .each(function (d, i) {
-          if (i === focus) {
+          if (focus.indexOf(i) > -1) {
             select(this)
               .attr('stroke', 'green')
               .attr('stroke-width', 3);
@@ -147,9 +147,9 @@ export default {
       .append('g')
       .classed('dff', true)
       .attr('transform', (d, i) => `translate(0, ${i * 512 / 50})`)
-      .on('mouseover', function (d, i) {
+      .on('click', function (d, i) {
         if (that.mode === 'selection') {
-          that.$store.commit('focus', i);
+          that.$store.commit('toggle', i);
         }
       });
 

--- a/src/components/DffPlot.vue
+++ b/src/components/DffPlot.vue
@@ -146,9 +146,7 @@ export default {
       .classed('dff', true)
       .attr('transform', (d, i) => `translate(0, ${i * 512 / 50})`)
       .on('click', function (d, i) {
-        if (that.mode === 'selection') {
-          that.$store.commit('toggle', i);
-        }
+        that.$store.commit('toggle', i);
       });
 
     // Create mouse target elements for interaction.

--- a/src/components/ROIPlot/index.vue
+++ b/src/components/ROIPlot/index.vue
@@ -117,6 +117,16 @@ export default {
       }
     },
 
+    drawSelectionROI (which, focused) {
+      const focusColor = { r: 0, g: 255, b: 0 };
+      const brightColor = { r: 100, g: 100, b: 100 };
+      const darkColor = { r: 50, g: 50, b: 50 };
+
+      const color = focused ? focusColor : (which < 50 ? brightColor : darkColor);
+
+      this.drawROI(which, color, false);
+    },
+
     drawIntensityROIs () {
       const dff = this.dff;
       const timeIndex = this.timeIndex;
@@ -137,49 +147,50 @@ export default {
     },
 
     setFocus (newFocus, oldFocus) {
+      const mode = this.mode;
+      const dff = this.dff;
+      const timeIndex = this.timeIndex;
       oldFocus.forEach(d => {
-        this.drawROI(d, {
-          r: 100,
-          g: 100,
-          b: 100
-        });
+        if (mode === 'selection') {
+          this.drawSelectionROI(d, false);
+        } else {
+          this.drawIntensityROI(d, dff[d][timeIndex], false);
+        }
       });
 
       newFocus.forEach(d => {
-        this.drawROI(d, {
-          r: 0,
-          g: 255,
-          b: 0
-        });
+        if (mode === 'selection') {
+          this.drawSelectionROI(d, true);
+        } else {
+          this.drawIntensityROI(d, dff[d][timeIndex], true);
+        }
       });
 
       this.img.update();
     },
 
     click () {
-      if (this.mode === 'selection') {
-        // Time out here to give canvas element a chance to pick up the mouse
-        // click and record its coordinates.
-        window.setTimeout(() => {
-          const mouse = this.img.click;
+      // Time out here to give canvas element a chance to pick up the mouse
+      // click and record its coordinates.
+      window.setTimeout(() => {
+        const mouse = this.img.click;
 
-          // Find a match.
-          const rois = this.rois;
-          let i;
+        // Find a match.
+        const rois = this.rois;
+        let i;
 loop:
-          for (i = 0; i < rois.length; i++) {
-            for (let j = 0; j < rois[i].length; j++) {
-              if (rois[i][j][0] === mouse.x && rois[i][j][1] === mouse.y) {
-                break loop;
-              }
+        for (i = 0; i < rois.length; i++) {
+          for (let j = 0; j < rois[i].length; j++) {
+            if (rois[i][j][0] === mouse.x && rois[i][j][1] === mouse.y) {
+              break loop;
             }
           }
+        }
 
-          if (i < 50) {
-            this.$store.commit('toggle', i);
-          }
-        }, 0);
-      }
+        if (i < 50) {
+          this.$store.commit('toggle', i);
+        }
+      }, 0);
     }
   }
 }

--- a/src/components/ROIPlot/index.vue
+++ b/src/components/ROIPlot/index.vue
@@ -55,10 +55,10 @@ export default {
       this.img.clear(0, 0, 0, 255);
 
       if (mode === 'selection') {
-        this.setFocus(this.focus, null);
         this.drawSelectionROIs();
+        this.setFocus(this.focus, []);
       } else {
-        this.setFocus(null, this.focus);
+        this.setFocus([], this.focus);
         this.drawIntensityROIs();
       }
 
@@ -131,21 +131,21 @@ export default {
     },
 
     setFocus (newFocus, oldFocus) {
-      if (oldFocus !== null) {
-        this.drawROI(oldFocus, {
+      oldFocus.forEach(d => {
+        this.drawROI(d, {
           r: 100,
           g: 100,
           b: 100
         });
-      }
+      });
 
-      if (newFocus !== null) {
-        this.drawROI(newFocus, {
+      newFocus.forEach(d => {
+        this.drawROI(d, {
           r: 0,
           g: 255,
           b: 0
         });
-      }
+      });
 
       this.img.update();
     },
@@ -169,7 +169,9 @@ loop:
             }
           }
 
-          this.$store.commit('focus', i < 50 ? i : null);
+          if (i < 50) {
+            this.$store.commit('toggle', i);
+          }
         }, 0);
       }
     }

--- a/src/components/ROIPlot/index.vue
+++ b/src/components/ROIPlot/index.vue
@@ -120,14 +120,20 @@ export default {
     drawIntensityROIs () {
       const dff = this.dff;
       const timeIndex = this.timeIndex;
+      const focus = this.focus;
       for (let i = 0; i < 50; i++) {
-        const color = this.intensity(dff[i][timeIndex]);
-        this.drawROI(i, {
-          r: color,
-          g: color,
-          b: color
-        }, false);
+        const focused = focus.indexOf(i) > -1;
+        this.drawIntensityROI(i, dff[i][timeIndex], focused);
       }
+    },
+
+    drawIntensityROI (which, value, focused) {
+      const color = this.intensity(value);
+      this.drawROI(which, {
+        r: focused ? 0 : color,
+        g: color,
+        b: focused ? 0 : color,
+      }, false);
     },
 
     setFocus (newFocus, oldFocus) {

--- a/src/main.js
+++ b/src/main.js
@@ -23,7 +23,7 @@ async function main () {
       rois: [],
       dff: [],
       epochs: [],
-      focus: null,
+      focus: [],
       timeIndex: 0,
       mode: 'selection'
     },
@@ -39,6 +39,27 @@ async function main () {
 
       focus (state, which) {
         state.focus = which;
+      },
+
+      toggle (state, which) {
+        const focus = state.focus;
+
+        // Copy the focus elements over if they do not match the target; this
+        // will toggle that element off if it is current in focus.
+        let out = [];
+        focus.forEach(d => {
+          if (d !== which) {
+            out.push(d);
+          }
+        });
+
+        // If the output length is the same as the input length, then the
+        // element wasn't found and we must therefore turn it on.
+        if (out.length === focus.length) {
+          out.push(which);
+        }
+
+        state.focus = out;
       },
 
       mode (state, mode) {


### PR DESCRIPTION
This allows both selection and time mode to make use of the selection concept, and generalizes selections to not be unique.

Clicking on either an ROI or a trace now toggles the presence of that ROI+trace in the selection. The trace will be rendered in green, and the ROI will be displayed either in a hard green (in selection mode) or in a shade of green reflecting the DF/F value (time mode).

attn @mgrauer